### PR TITLE
Fix git checkout error

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,7 @@ steps:
 
 - pwsh: |
     # Checkout the source branch
+    git fetch --all
     git checkout $(Build.SourceBranchName)
 
     # Get all variable groups


### PR DESCRIPTION
git checkout master error: "error: pathspec 'master' did not match any file(s) known to git"

solution: add "git fetch --all" just before git checkout command